### PR TITLE
Avoid mapping explosion

### DIFF
--- a/internal/projection/process/default_fields.go
+++ b/internal/projection/process/default_fields.go
@@ -16,9 +16,17 @@ func getDefaultFieldsToUnpack() []string {
 	}
 }
 
-func getDefaultFieldsMapToList() []string {
+func getDefaultFieldsMapToListDropKey() []string {
 	return []string{
 		"cluster.feature_usage",
+	}
+}
+
+func getDefaultFieldsMapToList() []string {
+	return []string{
+		"cluster.connectivity_majority_groups",
+		"cluster.hosts[*].disks_info",
+		"cluster.hosts[*].images_status",
 	}
 }
 

--- a/internal/projection/process/event_enricher.go
+++ b/internal/projection/process/event_enricher.go
@@ -11,20 +11,22 @@ import (
 )
 
 type EventEnricher struct {
-	logger            *logrus.Logger
-	fieldsToUnpack    []string
-	fieldsMapToList   []string
-	fieldsToDelete    []string
-	fieldsToAnonymize map[string]string
+	logger                 *logrus.Logger
+	fieldsToUnpack         []string
+	fieldsMapToList        []string
+	fieldsMapToListDropKey []string
+	fieldsToDelete         []string
+	fieldsToAnonymize      map[string]string
 }
 
 func NewEventEnricher(logger *logrus.Logger) *EventEnricher {
 	return &EventEnricher{
-		logger:            logger,
-		fieldsToUnpack:    getDefaultFieldsToUnpack(),
-		fieldsMapToList:   getDefaultFieldsMapToList(),
-		fieldsToDelete:    getDefaultFieldsToDelete(),
-		fieldsToAnonymize: getDefaultFieldsToAnonymize(),
+		logger:                 logger,
+		fieldsToUnpack:         getDefaultFieldsToUnpack(),
+		fieldsMapToList:        getDefaultFieldsMapToList(),
+		fieldsMapToListDropKey: getDefaultFieldsMapToListDropKey(),
+		fieldsToDelete:         getDefaultFieldsToDelete(),
+		fieldsToAnonymize:      getDefaultFieldsToAnonymize(),
 	}
 }
 
@@ -48,7 +50,11 @@ func (e *EventEnricher) getTransformedEvent(enrichedEvent *types.EnrichedEvent) 
 	if err != nil {
 		e.logger.WithError(err).Debug("error unpacking json")
 	}
-	transformedJson, err := mapToListJson(unpackedJson, e.fieldsMapToList)
+	transformedJson, err := mapToListJsonDropKey(unpackedJson, e.fieldsMapToListDropKey)
+	if err != nil {
+		e.logger.WithError(err).Debug("error transforming json")
+	}
+	transformedJson, err = mapToListJson(transformedJson, e.fieldsMapToList)
 	if err != nil {
 		e.logger.WithError(err).Debug("error transforming json")
 	}

--- a/internal/projection/process/transform.go
+++ b/internal/projection/process/transform.go
@@ -15,7 +15,7 @@ func unpackJson(jsonBytes []byte, paths []string) ([]byte, error) {
 }
 
 // Transforms defined values from map to list (removing the first level key)
-func mapToListJson(jsonBytes []byte, paths []string) ([]byte, error) {
+func mapToListJsonDropKey(jsonBytes []byte, paths []string) ([]byte, error) {
 	mapToList := func(unpacked interface{}) (interface{}, error) {
 		srcMap, ok := unpacked.(map[string]interface{})
 		if !ok {
@@ -24,6 +24,32 @@ func mapToListJson(jsonBytes []byte, paths []string) ([]byte, error) {
 		var dstList []interface{}
 		for _, v := range srcMap {
 			dstList = append(dstList, v)
+		}
+		return dstList, nil
+	}
+	return jsonedit.Transform(jsonBytes, paths, mapToList)
+}
+
+// Transforms defined values from map to list.
+// Keeps first level key as "id" if item value is map-like, otherwise
+// creates each item to be a map like: {"key": key, "value": value}
+func mapToListJson(jsonBytes []byte, paths []string) ([]byte, error) {
+	mapToList := func(unpacked interface{}) (interface{}, error) {
+		srcMap, ok := unpacked.(map[string]interface{})
+		if !ok {
+			return unpacked, fmt.Errorf("Field is not a map")
+		}
+		var dstList []interface{}
+		for k, v := range srcMap {
+			if item, ok := v.(map[string]interface{}); ok {
+				item["id"] = k
+				dstList = append(dstList, item)
+			} else {
+				item := map[string]interface{}{}
+				item["key"] = k
+				item["value"] = v
+				dstList = append(dstList, item)
+			}
 		}
 		return dstList, nil
 	}

--- a/internal/repository/opensearch/enriched_event_repository.go
+++ b/internal/repository/opensearch/enriched_event_repository.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
 	opensearch "github.com/opensearch-project/opensearch-go"
@@ -61,9 +62,10 @@ func (r *EnrichedEventRepository) Store(ctx context.Context, enrichedEvent *type
 			r.ackChannel <- *msg
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, resp opensearchutil.BulkIndexerResponseItem, err error) {
+			bodyBytes, _ := io.ReadAll(item.Body)
 			r.logger.WithError(err).WithFields(logrus.Fields{
 				"document_id": item.DocumentID,
-				"item":        item,
+				"item":        string(bodyBytes),
 				"action":      item.Action,
 				"index":       item.Index,
 				"response":    resp,


### PR DESCRIPTION
We store some fields as follow:
```
...
"disks_info": {
"disk-id": {"disk-property":1}
}
```
This means that we will have a lot of possible property names (1 each disk ID) which can cause issues in opensearch. To avoid issues, opensearch limits by default how many fields a mapping can have, and we're hitting this limit.

Changing this structure to a list would solve the issue.