### PR TITLE
MGMT-14180: Adding release_tag field to projected data

### DIFF
--- a/internal/types/event.go
+++ b/internal/types/event.go
@@ -26,6 +26,7 @@ type EnrichedEvent struct {
 	Cluster      map[string]interface{}   `json:"cluster"`
 	InfraEnvs    []map[string]interface{} `json:"infra_envs,omitempty"`
 	Versions     map[string]interface{}   `json:"versions"`
+	ReleaseTag   *string                  `json:"release_tag,omitempty"`
 }
 
 type EmbeddedEvent struct {


### PR DESCRIPTION
Currently `release_tag` is stored as part of the `versions` in integration, compared to the other environments where it is stored in the event. We want to add the `release_tag` to output the same way (event scope) for both options