### PR TITLE
ci: fix linting

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,13 +8,14 @@ ENV GOROOT=/usr/local/go
 ENV GOBIN="/usr/local/go/bin"
 ENV PATH=$PATH:$GOBIN:$GOROOT/bin
 
-RUN mkdir -p /usr/local/go/bin
+RUN go install github.com/golang/mock/mockgen@v1.6.0 &&\
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.7.0
+RUN chmod g+xw -R $GOPATH
+
 # Install kind
 RUN curl -sS -Lo ./kind https://kind.sigs.k8s.io/dl/v0.12.0/kind-linux-amd64 &&\
     install kind /usr/local/bin/kind && rm -f kind
 
-RUN go install github.com/golang/mock/mockgen@v1.6.0 &&\
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.7.0
 
 ENV GOFLAGS=-mod=vendor
 COPY --from=quay.io/openshift/origin-cli:4.10 /usr/bin/oc /usr/bin/kubectl /usr/bin/


### PR DESCRIPTION
Linting could not run in CI due to permission. Now that we use the same base image we can fix it for both local and CI