### PR TITLE
do not fail when message cannot be decoded

### DIFF
--- a/internal/projection/enriched_event_projection.go
+++ b/internal/projection/enriched_event_projection.go
@@ -51,7 +51,10 @@ func (p *EnrichedEventsProjection) ProcessMessage(ctx context.Context, msg *kafk
 
 	event, err := getEventFromMessage(msg)
 	if err != nil {
-		return err
+		p.logger.WithError(err).WithFields(logrus.Fields{
+			"message": msg,
+		}).Error("could not get event from message")
+		return nil
 	}
 	return p.ProcessEvent(ctx, event, msg)
 }

--- a/internal/projection/enriched_event_projection_test.go
+++ b/internal/projection/enriched_event_projection_test.go
@@ -49,6 +49,13 @@ var _ = Describe("Process message", func() {
 		mockInfraEnvs = getMockInfraEnvs()
 		mockEnrichedEvent = getMockEnrichedEvent()
 	})
+	When("Processing an invalid message", func() {
+		It("should not return error", func() {
+			msg := getKafkaMessage("not json")
+			err := projection.ProcessMessage(ctx, msg)
+			Expect(err).To(BeNil())
+		})
+	})
 	When("Processing a cluster event", func() {
 		It("should retrieve all related info and store it", func() {
 			eventPayload := getBasicClusterEventPayload()


### PR DESCRIPTION
This would lead to the consumer being stuck to the undecodable message.
This PR addresses this issue