### PR TITLE
add automation to create ACLs and topic

### DIFF
--- a/manifest/base/projection-template.yaml
+++ b/manifest/base/projection-template.yaml
@@ -11,6 +11,10 @@ parameters:
 - name: IMAGE_TAG
   value: ""
   required: true
+- name: KAFKA_IMAGE_NAME
+  value: "quay.io/strimzi/kafka"
+- name: KAFKA_IMAGE_TAG
+  value: "0.27.1-kafka-2.8.1"
 - name: CPU_LIMIT
   value: "1"
 - name: CPU_REQUEST
@@ -21,6 +25,12 @@ parameters:
   value: "256Mi"
 - name: NAMESPACE
   value: assisted-events-streams
+- name: KAFKA_TOPIC_PARTITIONS
+  value: "1"
+- name: KAFKA_TOPIC_REPLICATION_FACTOR
+  value: "1"
+- name: KAFKA_TOPIC_RETENTION_MS
+  value: "2419200000"
 - name: KAFKA_EVENT_STREAM_TOPIC
   value: "events-stream-integration"
 - name: KAFKA_GROUP_ID
@@ -46,14 +56,81 @@ parameters:
 - name: OPENSEARCH_RESPONSE_TIMEOUT
   value: "90s"
 - name: OPENSEARCH_SSL_INSECURE_SKIP_VERIFY
-  value: "false"
+  value: "true"
 - name: KAFKA_CREDENTIALS_SECRETNAME
-  value: assisted-installer-event-stream
+  value: kafka-dummy-user
+- name: KAFKA_CREDENTIALS_USERNAME_KEY
+  value: username
+- name: KAFKA_CREDENTIALS_PASSWORD_KEY
+  value: password
 - name: KAFKA_SASL_MECHANISM
   value: "PLAIN"
 - name: LOG_LEVEL
   value: info
+- name: ZOOKEEPER_TLS
+  value: "false"
+- name: ZOOKEEPER_CONNECT_STRING_SECRET_KEY
+  value: zookeeper_connect_string
+- name: ZOOKEEPER_CONNECT_STRING_SECRET_NAME
+  value: kafka
+- name: BOOTSTRAP_BROKERS_SECRET_KEY
+  value: bootstrap_brokers
+- name: BOOTSTRAP_BROKERS_SECRET_NAME
+  value: kafka
+- name: ADMIN_USERNAME_SECRET_KEY
+  value: username
+- name: ADMIN_USERNAME_SECRET_NAME
+  value: kafka-admin-user
+- name: ADMIN_PASSWORD_SECRET_KEY
+  value: password
+- name: ADMIN_PASSWORD_SECRET_NAME
+  value: kafka-admin-user
+- name: READ_USERNAME_SECRET_KEY
+  value: username
+- name: READ_USERNAME_SECRET_NAME
+  value: kafka-read-user
+- name: WRITE_USERNAME_SECRET_KEY
+  value: username
+- name: WRITE_USERNAME_SECRET_NAME
+  value: kafka-write-user
+- name: BOOTSTRAP_BROKERS_SECRET_KEY
+  value: bootstrap_brokers
+- name: BOOTSTRAP_BROKERS_SECRET_NAME
+  value: kafka
 objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: enriched-event-projection-zookeeper-client-config
+  data:
+    zookeeper.config: |-
+      zookeeper.ssl.client.enable=true
+      zookeeper.ssl.protocol=TLSv1.2
+      zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: enriched-event-projection-kafka-setup
+  data:
+    setup_acls: |-
+      export ZOOKEEPER=$(echo ${ZOOKEEPER_CONNECT_STRING} | cut -d, -f1)
+      ZK_TLS=""
+      if [ "${ZOOKEEPER_TLS}" == "true" ]; then
+        ZK_TLS="--zk-tls-config-file /opt/zookeeper/zookeeper.config"
+      fi
+      # setup admin user
+      /opt/kafka/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=${ZOOKEEPER} --add --allow-principal "User:${ADMIN_USERNAME}" ${ZK_TLS} --operation Create --cluster
+
+      # setup read user
+      /opt/kafka/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=${ZOOKEEPER} --add --allow-principal "User:${READ_USERNAME}" --operation Read --group "${KAFKA_GROUP_ID}" --topic "${KAFKA_TOPIC}" ${ZK_TLS}
+      # setup write user
+      /opt/kafka/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=${ZOOKEEPER} --add --allow-principal "User:${WRITE_USERNAME}" --operation Write --topic "${KAFKA_TOPIC}" ${ZK_TLS}
+    setup_topics: |
+      echo "sasl.mechanism=SCRAM-SHA-512\
+      security.protocol=SASL_SSL\
+      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${ADMIN_USERNAME} password="${ADMIN_PASSWORD}"\; > /tmp/admin-scram.properties
+
+      /opt/kafka/bin/kafka-topics.sh --bootstrap-server ${BOOTSTRAP_SERVERS} --command-config /tmp/admin-scram.properties --topic "${KAFKA_TOPIC}" --create --if-not-exists --partitions ${KAFKA_TOPIC_PARTITIONS} --replication-factor ${KAFKA_TOPIC_REPLICATION_FACTOR} --config retention.ms=${KAFKA_TOPIC_RETENTION_MS}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -68,6 +145,69 @@ objects:
         labels:
           app.kubernetes.io/name: enriched-event-projection
       spec:
+        volumes:
+        - name: scripts
+          configMap:
+            name: enriched-event-projection-kafka-setup
+            defaultMode: 0755
+        - name: zookeeper-config
+          configMap:
+            name: enriched-event-projection-zookeeper-client-config
+            defaultMode: 0744
+        initContainers:
+        - name: kafka-client
+          image: ${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}
+          volumeMounts:
+          - name: scripts
+            mountPath: /opt/scripts
+          - name: zookeeper-config
+            mountPath: /opt/zookeeper/zookeeper.config
+            subPath: zookeeper.config
+          env:
+          - name: KAFKA_TOPIC
+            value: ${KAFKA_EVENT_STREAM_TOPIC}
+          - name: KAFKA_TOPIC_PARTITIONS
+            value: "${KAFKA_TOPIC_PARTITIONS}"
+          - name: KAFKA_TOPIC_REPLICATION_FACTOR
+            value: "${KAFKA_TOPIC_REPLICATION_FACTOR}"
+          - name: KAFKA_TOPIC_RETENTION_MS
+            value: "2419200000"
+          - name: ADMIN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: ${ADMIN_USERNAME_SECRET_KEY}
+                name: ${ADMIN_USERNAME_SECRET_NAME}
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: ${ADMIN_PASSWORD_SECRET_KEY}
+                name: ${ADMIN_PASSWORD_SECRET_NAME}
+          - name: READ_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: ${READ_USERNAME_SECRET_KEY}
+                name: ${READ_USERNAME_SECRET_NAME}
+          - name: WRITE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: ${WRITE_USERNAME_SECRET_KEY}
+                name: ${WRITE_USERNAME_SECRET_NAME}
+          - name: ZOOKEEPER_TLS
+            value: "${ZOOKEEPER_TLS}"
+          - name: ZOOKEEPER_CONNECT_STRING
+            valueFrom:
+              secretKeyRef:
+                key: ${ZOOKEEPER_CONNECT_STRING_SECRET_KEY}
+                name: ${ZOOKEEPER_CONNECT_STRING_SECRET_NAME}
+          - name: BOOTSTRAP_SERVERS
+            valueFrom:
+              secretKeyRef:
+                key: ${BOOTSTRAP_BROKERS_SECRET_KEY}
+                name: ${BOOTSTRAP_BROKERS_SECRET_NAME}
+          command:
+          - bash
+          - -c
+          - "/opt/scripts/setup_acls && /opt/scripts/setup_topics"
         containers:
         - name: projection
           image: ${IMAGE_NAME}:${IMAGE_TAG}
@@ -105,18 +245,18 @@ objects:
           - name: KAFKA_BOOTSTRAP_SERVER
             valueFrom:
               secretKeyRef:
-                name: ${KAFKA_CREDENTIALS_SECRETNAME}
-                key: bootstrap_server_host
+                name: ${BOOTSTRAP_BROKERS_SECRET_NAME}
+                key: ${BOOTSTRAP_BROKERS_SECRET_KEY}
           - name: KAFKA_CLIENT_ID
             valueFrom:
               secretKeyRef:
                 name: ${KAFKA_CREDENTIALS_SECRETNAME}
-                key: client_id
+                key: ${KAFKA_CREDENTIALS_USERNAME_KEY}
           - name: KAFKA_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
                 name: ${KAFKA_CREDENTIALS_SECRETNAME}
-                key: client_secret
+                key: ${KAFKA_CREDENTIALS_PASSWORD_KEY}
           - name: REDIS_ADDRESS
             value: ${REDIS_ADDRESS}
           - name: REDIS_PASSWORD

--- a/manifest/components/kafka/kafka.yaml
+++ b/manifest/components/kafka/kafka.yaml
@@ -2,9 +2,58 @@
   path: /objects/0
   value:
     apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: ai-kafka
+      labels:
+        app.kubernetes.io/name: kafka
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: kafka
+      annotations:
+    automountServiceAccountToken: true
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ai-kafka-zookeeper-scripts
+      labels:
+        app.kubernetes.io/name: zookeeper
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: zookeeper
+    data:
+      init-certs.sh: |-
+        #!/bin/bash
+      setup.sh: |-
+        #!/bin/bash
+
+        # Execute entrypoint as usual after obtaining ZOO_SERVER_ID
+        # check ZOO_SERVER_ID in persistent volume via myid
+        # if not present, set based on POD hostname
+        if [[ -f "/bitnami/zookeeper/data/myid" ]]; then
+            export ZOO_SERVER_ID="$(cat /bitnami/zookeeper/data/myid)"
+        else
+            HOSTNAME="$(hostname -s)"
+            if [[ $HOSTNAME =~ (.*)-([0-9]+)$ ]]; then
+                ORD=${BASH_REMATCH[2]}
+                export ZOO_SERVER_ID="$((ORD + 1 ))"
+            else
+                echo "Failed to get index from hostname $HOST"
+                exit 1
+            fi
+        fi
+        exec /entrypoint.sh /run.sh
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: v1
     kind: ConfigMap
     metadata:
       name: ai-kafka-scripts
+      labels:
+        app.kubernetes.io/name: kafka
+        app.kubernetes.io/instance: ai-kafka
     data:
       setup.sh: |-
         #!/bin/bash
@@ -15,13 +64,68 @@
         else
             export KAFKA_CFG_BROKER_ID="$((ID + 0))"
         fi
-        export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=${KAFKA_CFG_BROKER_ID}@${MY_POD_NAME}.ai-kafka-headless.${NAMESPACE}.svc.cluster.local:9093
+
         # Configure zookeeper client
 
         exec /entrypoint.sh /run.sh
-      create_topic.sh: |-
-        #!/bin/bash
-        kafka-topics.sh --bootstrap-server localhost:9092 --topic events-stream --create --partitions 6 --replication-factor 1
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: ai-kafka-zookeeper-headless
+      labels:
+        app.kubernetes.io/name: zookeeper
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: zookeeper
+    spec:
+      type: ClusterIP
+      clusterIP: None
+      publishNotReadyAddresses: true
+      ports:
+        - name: tcp-client
+          port: 2181
+          targetPort: client
+        - name: tcp-follower
+          port: 2888
+          targetPort: follower
+        - name: tcp-election
+          port: 3888
+          targetPort: election
+      selector:
+        app.kubernetes.io/name: zookeeper
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: zookeeper
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: ai-kafka-zookeeper
+      labels:
+        app.kubernetes.io/name: zookeeper
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: zookeeper
+    spec:
+      type: ClusterIP
+      sessionAffinity: None
+      ports:
+        - name: tcp-client
+          port: 2181
+          targetPort: client
+          nodePort: null
+        - name: tcp-follower
+          port: 2888
+          targetPort: follower
+        - name: tcp-election
+          port: 3888
+          targetPort: election
+      selector:
+        app.kubernetes.io/name: zookeeper
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: zookeeper
 - op: add
   path: /objects/0
   value:
@@ -29,6 +133,10 @@
     kind: Service
     metadata:
       name: ai-kafka-headless
+      labels:
+        app.kubernetes.io/name: kafka
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: kafka
     spec:
       type: ClusterIP
       clusterIP: None
@@ -52,6 +160,10 @@
     kind: Service
     metadata:
       name: ai-kafka
+      labels:
+        app.kubernetes.io/name: kafka
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: kafka
     spec:
       type: ClusterIP
       sessionAffinity: None
@@ -65,6 +177,157 @@
         app.kubernetes.io/name: kafka
         app.kubernetes.io/instance: ai-kafka
         app.kubernetes.io/component: kafka
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      name: ai-kafka-zookeeper
+      labels:
+        app.kubernetes.io/name: zookeeper
+        app.kubernetes.io/instance: ai-kafka
+        app.kubernetes.io/component: zookeeper
+        role: zookeeper
+    spec:
+      replicas: 1
+      podManagementPolicy: Parallel
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: zookeeper
+          app.kubernetes.io/instance: ai-kafka
+          app.kubernetes.io/component: zookeeper
+      serviceName: ai-kafka-zookeeper-headless
+      updateStrategy:
+        rollingUpdate: {}
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+          labels:
+            app.kubernetes.io/name: zookeeper
+            app.kubernetes.io/instance: ai-kafka
+            app.kubernetes.io/component: zookeeper
+        spec:
+          serviceAccountName: default
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: zookeeper
+                        app.kubernetes.io/instance: ai-kafka
+                        app.kubernetes.io/component: zookeeper
+                    namespaces:
+                      - "${NAMESPACE}"
+                    topologyKey: kubernetes.io/hostname
+                  weight: 1
+          securityContext:
+            fsGroup: 1001
+          initContainers:
+          containers:
+            - name: zookeeper
+              image: docker.io/bitnami/zookeeper:3.8.0-debian-10-r64
+              imagePullPolicy: "IfNotPresent"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1001
+              command:
+                - /scripts/setup.sh
+              resources:
+                limits: {}
+                requests:
+                  cpu: 250m
+                  memory: 256Mi
+              env:
+                - name: BITNAMI_DEBUG
+                  value: "false"
+                - name: ZOO_DATA_LOG_DIR
+                  value: ""
+                - name: ZOO_PORT_NUMBER
+                  value: "2181"
+                - name: ZOO_TICK_TIME
+                  value: "2000"
+                - name: ZOO_INIT_LIMIT
+                  value: "10"
+                - name: ZOO_SYNC_LIMIT
+                  value: "5"
+                - name: ZOO_PRE_ALLOC_SIZE
+                  value: "65536"
+                - name: ZOO_SNAPCOUNT
+                  value: "100000"
+                - name: ZOO_MAX_CLIENT_CNXNS
+                  value: "60"
+                - name: ZOO_4LW_COMMANDS_WHITELIST
+                  value: "srvr, mntr, ruok"
+                - name: ZOO_LISTEN_ALLIPS_ENABLED
+                  value: "no"
+                - name: ZOO_AUTOPURGE_INTERVAL
+                  value: "0"
+                - name: ZOO_AUTOPURGE_RETAIN_COUNT
+                  value: "3"
+                - name: ZOO_MAX_SESSION_TIMEOUT
+                  value: "40000"
+                - name: ZOO_SERVERS
+                  value: ai-kafka-zookeeper-0.ai-kafka-zookeeper-headless.kafka.svc.cluster.local:2888:3888::1 
+                - name: ZOO_ENABLE_AUTH
+                  value: "no"
+                - name: ZOO_HEAP_SIZE
+                  value: "1024"
+                - name: ZOO_LOG_LEVEL
+                  value: "ERROR"
+                - name: ALLOW_ANONYMOUS_LOGIN
+                  value: "yes"
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.name
+              ports:
+                - name: client
+                  containerPort: 2181
+                - name: follower
+                  containerPort: 2888
+                - name: election
+                  containerPort: 3888
+              livenessProbe:
+                failureThreshold: 6
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+                exec:
+                  command: ['/bin/bash', '-c', 'echo "ruok" | timeout 2 nc -w 2 localhost 2181 | grep imok']
+              readinessProbe:
+                failureThreshold: 6
+                initialDelaySeconds: 5
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+                exec:
+                  command: ['/bin/bash', '-c', 'echo "ruok" | timeout 2 nc -w 2 localhost 2181 | grep imok']
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts/setup.sh
+                  subPath: setup.sh
+                - name: data
+                  mountPath: /bitnami/zookeeper
+          volumes:
+            - name: scripts
+              configMap:
+                name: ai-kafka-zookeeper-scripts
+                defaultMode: 0755
+      volumeClaimTemplates:
+        - metadata:
+            name: data
+            annotations:
+          spec:
+            accessModes:
+              - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: "8Gi"
 - op: add
   path: /objects/0
   value:
@@ -112,20 +375,19 @@
                     topologyKey: kubernetes.io/hostname
                   weight: 1
             nodeAffinity:
+          serviceAccountName: ai-kafka
           containers:
             - name: kafka
               image: docker.io/bitnami/kafka:3.2.0-debian-10-r4
               imagePullPolicy: "IfNotPresent"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1001
               command:
                 - /scripts/setup.sh
-              lifecycle:
-                postStart:
-                  exec:
-                    command:
-                      - /scripts/create_topic.sh
               env:
                 - name: BITNAMI_DEBUG
-                  value: "true"
+                  value: "false"
                 - name: MY_POD_IP
                   valueFrom:
                     fieldRef:
@@ -136,14 +398,16 @@
                       fieldPath: metadata.name
                 - name: KAFKA_CFG_ZOOKEEPER_CONNECT
                   value: "ai-kafka-zookeeper"
-                - name: KAFKA_ENABLE_KRAFT
-                  value: "yes"
                 - name: KAFKA_INTER_BROKER_LISTENER_NAME
                   value: "PLAINTEXT"
                 - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
                   value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+                - name: KAFKA_CFG_SASL_ENABLED_MECHANISMS
+                  value: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
+                - name: KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL
+                  value: "PLAIN"
                 - name: KAFKA_CFG_LISTENERS
-                  value: "PLAINTEXT://:9092,CONTROLLER://:9093"
+                  value: "CONTROLLER://:9093,PLAINTEXT://:9092"
                 - name: KAFKA_CFG_ADVERTISED_LISTENERS
                   value: "PLAINTEXT://$(MY_POD_NAME).ai-kafka-headless.${NAMESPACE}.svc.cluster.local:9092"
                 - name: ALLOW_PLAINTEXT_LISTENER
@@ -154,10 +418,6 @@
                   value: "/bitnami/kafka"
                 - name: KAFKA_LOG_DIR
                   value: "/opt/bitnami/kafka/logs"
-                - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
-                  value: CONTROLLER
-                - name: KAFKA_CFG_PROCESS_ROLES
-                  value: broker,controller
                 - name: KAFKA_CFG_DELETE_TOPIC_ENABLE
                   value: "false"
                 - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
@@ -235,14 +495,13 @@
                 limits: {}
                 requests: {}
               volumeMounts:
+                - name: data
+                  mountPath: /bitnami/kafka
                 - name: logs
                   mountPath: /opt/bitnami/kafka/logs
                 - name: scripts
                   mountPath: /scripts/setup.sh
                   subPath: setup.sh
-                - name: scripts
-                  mountPath: /scripts/create_topic.sh
-                  subPath: create_topic.sh
           volumes:
             - name: scripts
               configMap:
@@ -250,3 +509,12 @@
                 defaultMode: 0755
             - name: logs
               emptyDir: {}
+      volumeClaimTemplates:
+        - metadata:
+            name: data
+          spec:
+            accessModes:
+              - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: "8Gi"

--- a/manifest/overlays/dev/kafka-secrets.yaml
+++ b/manifest/overlays/dev/kafka-secrets.yaml
@@ -4,12 +4,52 @@
     apiVersion: v1
     kind: Secret
     metadata:
+      name: kafka
+    type: Opaque
+    stringData:
+      zookeeper_connect_string: ai-kafka-zookeeper-0.ai-kafka-zookeeper-headless.assisted-events-streams.svc.cluster.local:2181
+      bootstrap_brokers: ai-kafka-0.ai-kafka-headless.assisted-events-streams.svc.cluster.local:9092
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kafka-admin-user
+    type: Opaque
+    stringData:
+      username: admin
+      password: pleaseletmein
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kafka-read-user
+    type: Opaque
+    stringData:
+      username: read
+      password: pleaseletmein
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kafka-write-user
+    type: Opaque
+    stringData:
+      username: write
+      password: pleaseletmein
+- op: add
+  path: /objects/0
+  value:
+    apiVersion: v1
+    kind: Secret
+    metadata:
       name: ${KAFKA_CREDENTIALS_SECRETNAME}
     type: Opaque
-    data:
-      # "ai-kafka-0.ai-kafka-headless.${NAMESPACE}.svc.cluster.local:9092"
-      bootstrap_server_host: YWkta2Fma2EtMC5haS1rYWZrYS1oZWFkbGVzcy5hc3Npc3RlZC1ldmVudHMtc3RyZWFtcy5zdmMuY2x1c3Rlci5sb2NhbDo5MDky
-      client_id:
-      client_secret:
-      metrics:
-      token_url:
+    stringData:
+      username: ""
+      password: ""

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -373,6 +373,39 @@ objects:
       app.kubernetes.io/instance: assisted-events-streams
       app.kubernetes.io/name: redis
     name: assisted-events-streams-redis-configuration
+- apiVersion: v1
+  data:
+    zookeeper.config: |-
+      zookeeper.ssl.client.enable=true
+      zookeeper.ssl.protocol=TLSv1.2
+      zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
+  kind: ConfigMap
+  metadata:
+    name: enriched-event-projection-zookeeper-client-config
+- apiVersion: v1
+  data:
+    setup_acls: |-
+      export ZOOKEEPER=$(echo ${ZOOKEEPER_CONNECT_STRING} | cut -d, -f1)
+      ZK_TLS=""
+      if [ "${ZOOKEEPER_TLS}" == "true" ]; then
+        ZK_TLS="--zk-tls-config-file /opt/zookeeper/zookeeper.config"
+      fi
+      # setup admin user
+      /opt/kafka/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=${ZOOKEEPER} --add --allow-principal "User:${ADMIN_USERNAME}" ${ZK_TLS} --operation Create --cluster
+
+      # setup read user
+      /opt/kafka/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=${ZOOKEEPER} --add --allow-principal "User:${READ_USERNAME}" --operation Read --group "${KAFKA_GROUP_ID}" --topic "${KAFKA_TOPIC}" ${ZK_TLS}
+      # setup write user
+      /opt/kafka/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=${ZOOKEEPER} --add --allow-principal "User:${WRITE_USERNAME}" --operation Write --topic "${KAFKA_TOPIC}" ${ZK_TLS}
+    setup_topics: |
+      echo "sasl.mechanism=SCRAM-SHA-512\
+      security.protocol=SASL_SSL\
+      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${ADMIN_USERNAME} password="${ADMIN_PASSWORD}"\; > /tmp/admin-scram.properties
+
+      /opt/kafka/bin/kafka-topics.sh --bootstrap-server ${BOOTSTRAP_SERVERS} --command-config /tmp/admin-scram.properties --topic "${KAFKA_TOPIC}" --create --if-not-exists --partitions ${KAFKA_TOPIC_PARTITIONS} --replication-factor ${KAFKA_TOPIC_REPLICATION_FACTOR} --config retention.ms=${KAFKA_TOPIC_RETENTION_MS}
+  kind: ConfigMap
+  metadata:
+    name: enriched-event-projection-kafka-setup
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -414,17 +447,17 @@ objects:
           - name: KAFKA_BOOTSTRAP_SERVER
             valueFrom:
               secretKeyRef:
-                key: bootstrap_server_host
-                name: ${KAFKA_CREDENTIALS_SECRETNAME}
+                key: ${BOOTSTRAP_BROKERS_SECRET_KEY}
+                name: ${BOOTSTRAP_BROKERS_SECRET_NAME}
           - name: KAFKA_CLIENT_ID
             valueFrom:
               secretKeyRef:
-                key: client_id
+                key: ${KAFKA_CREDENTIALS_USERNAME_KEY}
                 name: ${KAFKA_CREDENTIALS_SECRETNAME}
           - name: KAFKA_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                key: client_secret
+                key: ${KAFKA_CREDENTIALS_PASSWORD_KEY}
                 name: ${KAFKA_CREDENTIALS_SECRETNAME}
           - name: REDIS_ADDRESS
             value: ${REDIS_ADDRESS}
@@ -460,6 +493,69 @@ objects:
             requests:
               cpu: ${CPU_REQUEST}
               memory: ${MEMORY_REQUEST}
+        initContainers:
+        - command:
+          - bash
+          - -c
+          - /opt/scripts/setup_acls && /opt/scripts/setup_topics
+          env:
+          - name: KAFKA_TOPIC
+            value: ${KAFKA_EVENT_STREAM_TOPIC}
+          - name: KAFKA_TOPIC_PARTITIONS
+            value: ${KAFKA_TOPIC_PARTITIONS}
+          - name: KAFKA_TOPIC_REPLICATION_FACTOR
+            value: ${KAFKA_TOPIC_REPLICATION_FACTOR}
+          - name: KAFKA_TOPIC_RETENTION_MS
+            value: "2419200000"
+          - name: ADMIN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: ${ADMIN_USERNAME_SECRET_KEY}
+                name: ${ADMIN_USERNAME_SECRET_NAME}
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: ${ADMIN_PASSWORD_SECRET_KEY}
+                name: ${ADMIN_PASSWORD_SECRET_NAME}
+          - name: READ_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: ${READ_USERNAME_SECRET_KEY}
+                name: ${READ_USERNAME_SECRET_NAME}
+          - name: WRITE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: ${WRITE_USERNAME_SECRET_KEY}
+                name: ${WRITE_USERNAME_SECRET_NAME}
+          - name: ZOOKEEPER_TLS
+            value: ${ZOOKEEPER_TLS}
+          - name: ZOOKEEPER_CONNECT_STRING
+            valueFrom:
+              secretKeyRef:
+                key: ${ZOOKEEPER_CONNECT_STRING_SECRET_KEY}
+                name: ${ZOOKEEPER_CONNECT_STRING_SECRET_NAME}
+          - name: BOOTSTRAP_SERVERS
+            valueFrom:
+              secretKeyRef:
+                key: ${BOOTSTRAP_BROKERS_SECRET_KEY}
+                name: ${BOOTSTRAP_BROKERS_SECRET_NAME}
+          image: ${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}
+          name: kafka-client
+          volumeMounts:
+          - mountPath: /opt/scripts
+            name: scripts
+          - mountPath: /opt/zookeeper/zookeeper.config
+            name: zookeeper-config
+            subPath: zookeeper.config
+        volumes:
+        - configMap:
+            defaultMode: 493
+            name: enriched-event-projection-kafka-setup
+          name: scripts
+        - configMap:
+            defaultMode: 484
+            name: enriched-event-projection-zookeeper-client-config
+          name: zookeeper-config
 parameters:
 - name: REDIS_EXPORTER_IMAGE_TAG
   value: 1.37.0-debian-10-r63
@@ -480,6 +576,10 @@ parameters:
 - name: IMAGE_TAG
   required: true
   value: ""
+- name: KAFKA_IMAGE_NAME
+  value: quay.io/strimzi/kafka
+- name: KAFKA_IMAGE_TAG
+  value: 0.27.1-kafka-2.8.1
 - name: CPU_LIMIT
   value: "1"
 - name: CPU_REQUEST
@@ -490,6 +590,12 @@ parameters:
   value: 256Mi
 - name: NAMESPACE
   value: assisted-events-streams
+- name: KAFKA_TOPIC_PARTITIONS
+  value: "1"
+- name: KAFKA_TOPIC_REPLICATION_FACTOR
+  value: "1"
+- name: KAFKA_TOPIC_RETENTION_MS
+  value: "2419200000"
 - name: KAFKA_EVENT_STREAM_TOPIC
   value: events-stream-integration
 - name: KAFKA_GROUP_ID
@@ -515,10 +621,44 @@ parameters:
 - name: OPENSEARCH_RESPONSE_TIMEOUT
   value: 90s
 - name: OPENSEARCH_SSL_INSECURE_SKIP_VERIFY
-  value: "false"
+  value: "true"
 - name: KAFKA_CREDENTIALS_SECRETNAME
-  value: assisted-installer-event-stream
+  value: kafka-dummy-user
+- name: KAFKA_CREDENTIALS_USERNAME_KEY
+  value: username
+- name: KAFKA_CREDENTIALS_PASSWORD_KEY
+  value: password
 - name: KAFKA_SASL_MECHANISM
   value: PLAIN
 - name: LOG_LEVEL
   value: info
+- name: ZOOKEEPER_TLS
+  value: "false"
+- name: ZOOKEEPER_CONNECT_STRING_SECRET_KEY
+  value: zookeeper_connect_string
+- name: ZOOKEEPER_CONNECT_STRING_SECRET_NAME
+  value: kafka
+- name: BOOTSTRAP_BROKERS_SECRET_KEY
+  value: bootstrap_brokers
+- name: BOOTSTRAP_BROKERS_SECRET_NAME
+  value: kafka
+- name: ADMIN_USERNAME_SECRET_KEY
+  value: username
+- name: ADMIN_USERNAME_SECRET_NAME
+  value: kafka-admin-user
+- name: ADMIN_PASSWORD_SECRET_KEY
+  value: password
+- name: ADMIN_PASSWORD_SECRET_NAME
+  value: kafka-admin-user
+- name: READ_USERNAME_SECRET_KEY
+  value: username
+- name: READ_USERNAME_SECRET_NAME
+  value: kafka-read-user
+- name: WRITE_USERNAME_SECRET_KEY
+  value: username
+- name: WRITE_USERNAME_SECRET_NAME
+  value: kafka-write-user
+- name: BOOTSTRAP_BROKERS_SECRET_KEY
+  value: bootstrap_brokers
+- name: BOOTSTRAP_BROKERS_SECRET_NAME
+  value: kafka


### PR DESCRIPTION
As the new kafka provider does not provide this kind of automation, we need to do it ourselves.
Also added zookeeper locally, to be able to test this locally.

This deployment is incompatible with whatever was there before, so we are going to break the environments on deployment.
As it's not impacting anything, we decided to go this route (easiest).