### PR TITLE
fix script indentation

### DIFF
--- a/manifest/base/projection-template.yaml
+++ b/manifest/base/projection-template.yaml
@@ -132,9 +132,11 @@ objects:
       # setup write user
       /opt/kafka/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=${ZOOKEEPER} --add --allow-principal "User:${WRITE_USERNAME}" --operation Write --topic "${KAFKA_TOPIC}" ${ZK_TLS}
     setup_topics: |
-      echo "sasl.mechanism=SCRAM-SHA-512\
-      security.protocol=SASL_SSL\
-      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${ADMIN_USERNAME} password="${ADMIN_PASSWORD}"\; > /tmp/admin-scram.properties
+      echo "sasl.mechanism=SCRAM-SHA-512
+      security.protocol=SASL_SSL
+      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \\
+           username=\"${ADMIN_USERNAME}\" \\
+           password=\"${ADMIN_PASSWORD}\""; > /tmp/admin-scram.properties
 
       /opt/kafka/bin/kafka-topics.sh --bootstrap-server ${BOOTSTRAP_SERVERS} --command-config /tmp/admin-scram.properties --topic "${KAFKA_TOPIC}" --create --if-not-exists --partitions ${KAFKA_TOPIC_PARTITIONS} --replication-factor ${KAFKA_TOPIC_REPLICATION_FACTOR} --config retention.ms=${KAFKA_TOPIC_RETENTION_MS}
 - apiVersion: apps/v1

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -398,9 +398,11 @@ objects:
       # setup write user
       /opt/kafka/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=${ZOOKEEPER} --add --allow-principal "User:${WRITE_USERNAME}" --operation Write --topic "${KAFKA_TOPIC}" ${ZK_TLS}
     setup_topics: |
-      echo "sasl.mechanism=SCRAM-SHA-512\
-      security.protocol=SASL_SSL\
-      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${ADMIN_USERNAME} password="${ADMIN_PASSWORD}"\; > /tmp/admin-scram.properties
+      echo "sasl.mechanism=SCRAM-SHA-512
+      security.protocol=SASL_SSL
+      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \\
+           username=\"${ADMIN_USERNAME}\" \\
+           password=\"${ADMIN_PASSWORD}\""; > /tmp/admin-scram.properties
 
       /opt/kafka/bin/kafka-topics.sh --bootstrap-server ${BOOTSTRAP_SERVERS} --command-config /tmp/admin-scram.properties --topic "${KAFKA_TOPIC}" --create --if-not-exists --partitions ${KAFKA_TOPIC_PARTITIONS} --replication-factor ${KAFKA_TOPIC_REPLICATION_FACTOR} --config retention.ms=${KAFKA_TOPIC_RETENTION_MS}
   kind: ConfigMap


### PR DESCRIPTION
In prod this mangled the config file to be all one-line, I have wrongly assumed that it worked because local was working.

This worked in local because the credentials were not necessary :unamused: 