### PR TITLE
ack messages when processing state

### DIFF
--- a/internal/projection/utils.go
+++ b/internal/projection/utils.go
@@ -16,5 +16,6 @@ func NewEnrichedEventsProjectionFromEnv(ctx context.Context, logger *logrus.Logg
 		logger,
 		snapshotRepository,
 		enrichedEventRepository,
+		ackChannel,
 	)
 }


### PR DESCRIPTION
When a lot of messages are produced but only by changing state (no actual event in the service), we can see huge increase of uncommitted messages.

This would lead to inefficiency if the projection pod would restart/crash, by reprocessing those events again.