### PR TITLE
remove malformed ID field (coming from onprem)

### DIFF
--- a/internal/projection/process/event_enricher.go
+++ b/internal/projection/process/event_enricher.go
@@ -93,14 +93,20 @@ func (e *EventEnricher) GetBaseEnrichedEvent(event *types.Event, cluster map[str
 	if err != nil {
 		return nil, fmt.Errorf("Error getting uuid namespace, most likely seed is not 16 characters")
 	}
-
 	enrichedEvent := &types.EnrichedEvent{}
 	props, err := getProps(event.Payload)
 	if err != nil {
 		e.logger.WithError(err).Debug("error while extracting event props")
 	}
 	enrichedEvent.Event.Properties = props
-	eventBytes, err := json.Marshal(event.Payload)
+
+	// remove ID, as it's passed as INT (only from onprem data)
+	payload, ok := event.Payload.(map[string]interface{})
+	if ok {
+		delete(payload, "ID")
+	}
+
+	eventBytes, err := json.Marshal(payload)
 	if err != nil {
 		return enrichedEvent, err
 	}


### PR DESCRIPTION
onprem data is exporting private fields, and unfortunately json encoder does not understand the difference between "id" and "ID", and tries to unmarshal an int ID into a string property.

We will need to stop sending this data, but we can mitigate this issue by ignoring this field (which we don't need anyway, at least not in this form)

/cc @adriengentil @CrystalChun 