### PR TITLE
ignore empty list curator

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -68,6 +68,7 @@ objects:
             Delete data from indices older than ${OPENSEARCH_CURATOR_DELETE_INDICES_AFTER_MONTHS} months
           options:
             continue_if_exception: False
+            ignore_empty_list: True
           filters:
           - filtertype: pattern
             kind: regex
@@ -84,6 +85,7 @@ objects:
           options:
             max_num_segments: ${OPENSEARCH_CURATOR_FORCEMERGE_MAX_SEGMENTS}
             timeout_override: ${OPENSEARCH_CURATOR_FORCEMERGE_TIMEOUT_SECONDS}
+            ignore_empty_list: True
           filters:
           - filtertype: pattern
             kind: regex


### PR DESCRIPTION
When no index found for given action, curator exits with error.
Although it does not really affect the behaviour, it triggers false positive alert