### PR TITLE
downsize to 0 replicas when index is more than 1 month old

### DIFF
--- a/manifest/base/projection-template.yaml
+++ b/manifest/base/projection-template.yaml
@@ -95,6 +95,8 @@ parameters:
   value: "True"
 - name: OPENSEARCH_CURATOR_DELETE_INDICES_AFTER_MONTHS
   value: "18"
+- name: OPENSEARCH_CURATOR_ZERO_REPLICAS_AFTER_MONTHS
+  value: "1"
 - name: OPENSEARCH_CURATOR_DELETE_INDICES_PATTERN
   value: '^(assisted-service-events|assisted-installer-events).*'
 - name: OPENSEARCH_PORT
@@ -181,6 +183,8 @@ parameters:
   value: "1000"
 - name: ONPREM_EVENT_CHANNEL_BUFFER_SIZE
   value: "1000"
+- name: REDIS_PVC_NAME
+  value: redis-data
 objects:
 - apiVersion: v1
   kind: ConfigMap

--- a/manifest/components/opensearch-curator/opensearch-curator.yaml
+++ b/manifest/components/opensearch-curator/opensearch-curator.yaml
@@ -21,11 +21,30 @@
       actions.yaml: |-
         actions:
           1:
+            action: replicas
+            description: >-
+              Reduce number of replicas to 0 for indices ${OPENSEARCH_CURATOR_ZERO_REPLICAS_AFTER_MONTHS} months
+            options:
+              count: 0
+              continue_if_exception: False
+              ignore_empty_list: True
+            filters:
+            - filtertype: pattern
+              kind: regex
+              value: ${OPENSEARCH_CURATOR_DELETE_INDICES_PATTERN}
+            - filtertype: age
+              source: creation_date
+              direction: older
+              unit: months
+              unit_count: ${OPENSEARCH_CURATOR_ZERO_REPLICAS_AFTER_MONTHS}
+        actions:
+          2:
             action: delete_indices
             description: >-
               Delete data from indices older than ${OPENSEARCH_CURATOR_DELETE_INDICES_AFTER_MONTHS} months
             options:
               continue_if_exception: False
+              ignore_empty_list: True
             filters:
             - filtertype: pattern
               kind: regex

--- a/manifest/components/redis/redis.yaml
+++ b/manifest/components/redis/redis.yaml
@@ -324,7 +324,7 @@
                   mountPath: /opt/bitnami/scripts/start-scripts
                 - name: health
                   mountPath: /health
-                - name: redis-data
+                - name: ${REDIS_PVC_NAME}
                   mountPath: /data
                   subPath: 
                 - name: config
@@ -381,7 +381,7 @@
               emptyDir: {}
       volumeClaimTemplates:
         - metadata:
-            name: redis-data
+            name: ${REDIS_PVC_NAME}
             labels:
               app.kubernetes.io/name: redis
               app.kubernetes.io/instance: assisted-events-streams

--- a/manifest/overlays/dev/parameters.yaml
+++ b/manifest/overlays/dev/parameters.yaml
@@ -11,6 +11,11 @@
 - op: add
   path: /parameters/0
   value:
+    name: REDIS_PVC_NAME
+    value: redis-data
+- op: add
+  path: /parameters/0
+  value:
     name: REDIS_IMAGE_NAME
     value: quay.io/edge-infrastructure/redis
 - op: add

--- a/manifest/overlays/production/parameters.yaml
+++ b/manifest/overlays/production/parameters.yaml
@@ -11,6 +11,11 @@
 - op: add
   path: /parameters/0
   value:
+    name: REDIS_PVC_NAME
+    value: redis-data
+- op: add
+  path: /parameters/0
+  value:
     name: REDIS_IMAGE_NAME
     value: quay.io/edge-infrastructure/redis
 - op: add

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -63,6 +63,24 @@ objects:
     actions.yaml: |-
       actions:
         1:
+          action: replicas
+          description: >-
+            Reduce number of replicas to 0 for indices ${OPENSEARCH_CURATOR_ZERO_REPLICAS_AFTER_MONTHS} months
+          options:
+            count: 0
+            continue_if_exception: False
+            ignore_empty_list: True
+          filters:
+          - filtertype: pattern
+            kind: regex
+            value: ${OPENSEARCH_CURATOR_DELETE_INDICES_PATTERN}
+          - filtertype: age
+            source: creation_date
+            direction: older
+            unit: months
+            unit_count: ${OPENSEARCH_CURATOR_ZERO_REPLICAS_AFTER_MONTHS}
+      actions:
+        2:
           action: delete_indices
           description: >-
             Delete data from indices older than ${OPENSEARCH_CURATOR_DELETE_INDICES_AFTER_MONTHS} months
@@ -776,10 +794,10 @@ parameters:
   value: 6.2.7-debian-10-r23
 - name: REDIS_IMAGE_NAME
   value: quay.io/edge-infrastructure/redis
-- name: REDIS_STORAGE
-  value: 100Gi
 - name: REDIS_PVC_NAME
   value: redis-data
+- name: REDIS_STORAGE
+  value: 100Gi
 - name: IMAGE_PULL_POLICY
   value: Always
 - name: REPLICAS_COUNT
@@ -873,6 +891,8 @@ parameters:
   value: "True"
 - name: OPENSEARCH_CURATOR_DELETE_INDICES_AFTER_MONTHS
   value: "18"
+- name: OPENSEARCH_CURATOR_ZERO_REPLICAS_AFTER_MONTHS
+  value: "1"
 - name: OPENSEARCH_CURATOR_DELETE_INDICES_PATTERN
   value: ^(assisted-service-events|assisted-installer-events).*
 - name: OPENSEARCH_PORT
@@ -959,3 +979,5 @@ parameters:
   value: "1000"
 - name: ONPREM_EVENT_CHANNEL_BUFFER_SIZE
   value: "1000"
+- name: REDIS_PVC_NAME
+  value: redis-data


### PR DESCRIPTION
In order to save disk space, we will downsize indices to have only 1 replica when one month old.
