### PR TITLE
KONFLUX-1611: Add labels, licenses & user to Dockerfile

### DIFF
--- a/.tekton/assisted-events-stream-saas-main-pull-request.yaml
+++ b/.tekton/assisted-events-stream-saas-main-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}
+    - version={{revision}}
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/assisted-events-stream-saas-main-push.yaml
+++ b/.tekton/assisted-events-stream-saas-main-push.yaml
@@ -27,6 +27,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}
+    - version={{revision}}
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+## Build
 FROM registry.access.redhat.com/ubi9/go-toolset:1.18 AS build
 
 USER root
@@ -8,9 +9,38 @@ RUN cd /app && CGO_ENABLED=0 go build -ldflags='-extldflags=-static' -o=projecti
 
 RUN cd /app && CGO_ENABLED=0 go build -ldflags='-extldflags=-static' -o=onprem ./cmd/onprem/main.go
 
+## Licenses
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18 AS licenses
+
+ADD . /app
+WORKDIR /app
+
+RUN go install github.com/google/go-licenses@v1.6.0
+RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
+
+## Runtime
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+
+ARG release=main
+ARG version=latest
+
+LABEL com.redhat.component assisted-events-stream
+LABEL description "Pipeline processors for assisted installer service events"
+LABEL summary "Pipeline processors for assisted installer service events"
+LABEL io.k8s.description "Pipeline processors for assisted installer service events"
+LABEL distribution-scope public
+LABEL name assisted-events-stream
+LABEL release ${release}
+LABEL version ${version}
+LABEL url https://github.com/openshift-assisted/assisted-events-stream
+LABEL vendor "Red Hat, Inc."
+LABEL maintainer "Red Hat"
+
+COPY --from=licenses /tmp/licenses /licenses
 
 COPY --from=build /app/projection /
 COPY --from=build /app/onprem /
+
+USER 1001:1001
 
 ENTRYPOINT ["/projection"]


### PR DESCRIPTION
* Add labels
* Add default user
* Add licenses under /licenses/

Requirements come from https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#additional_resources and would prevent us from releasing an image (we have an exception for "based_on_ubi image")
