### PR TITLE
MGMT-19127: Migrate assisted-events-stream to Konflux

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,7 +2,8 @@
 
 set -exu
 
-TAG=$(git rev-parse --short=7 HEAD)
+TAG=$(git rev-parse HEAD)
+SHORT_TAG=$(git rev-parse --short=7 HEAD)
 export IMAGE_NAME="quay.io/app-sre/assisted-events-stream"
 export IMAGE_TAG=$TAG
 export DOCKER_BUILDKIT=1
@@ -13,6 +14,8 @@ make redis-docker-build
 DOCKER_CONF="$PWD/assisted/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:${SHORT_TAG}"
 docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:latest"
 docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${SHORT_TAG}"
 docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:latest"


### PR DESCRIPTION
We want to change app-interface to deploy the images that Konflux builds and by default Konflux uses the full commit sha as the tag.
In order to avoid issues with telling app-interface to use the full commit sha, I am updating build_deploy.sh to push both the full sha and the short sha as image tags.

Part of [MGMT-19127](https://issues.redhat.com//browse/MGMT-19127)