### PR TITLE
fix: Push host state event first

### DIFF
--- a/internal/onprem/event_extractor.go
+++ b/internal/onprem/event_extractor.go
@@ -141,14 +141,14 @@ func (e *EventExtractor) readTarLine(logger *logrus.Entry, tarReader *tar.Reader
 func (e *EventExtractor) extractEvents(logger *logrus.Entry, tmpdir string, eventChannel chan types.EventEnvelope) {
 	eventTypesMatches := []EventTypeMatch{
 		{
-			glob:         "/*/events/cluster.json",
-			eventName:    "ClusterState",
-			clusterIDKey: "id",
-		},
-		{
 			glob:         "/*/events/hosts.json",
 			eventName:    "HostState",
 			clusterIDKey: "cluster_id",
+		},
+		{
+			glob:         "/*/events/cluster.json",
+			eventName:    "ClusterState",
+			clusterIDKey: "id",
 		},
 		{
 			glob:         "/*/events/infraenv.json",

--- a/internal/onprem/event_extractor_test.go
+++ b/internal/onprem/event_extractor_test.go
@@ -73,16 +73,16 @@ func assertEventIsInRightSequence(event types.EventEnvelope, eventNumber int, ex
 	payload, ok := event.Event.Payload.(map[string]interface{})
 	Expect(ok).To(Equal(true))
 	assertHasVersions(event.Event)
-	if eventNumber <= expectedClusterEvents {
-		Expect(event.Event.Name).To(Equal("ClusterState"))
-		clusterID, ok := payload["id"].(string)
+	if eventNumber <= expectedHostEvents {
+		Expect(event.Event.Name).To(Equal("HostState"))
+		clusterID, ok := payload["cluster_id"].(string)
 		Expect(ok).To(Equal(true))
 		Expect(clusterID).To(Equal(expectedClusterID))
 		return
 	}
 	if eventNumber <= (expectedClusterEvents + expectedHostEvents) {
-		Expect(event.Event.Name).To(Equal("HostState"))
-		clusterID, ok := payload["cluster_id"].(string)
+		Expect(event.Event.Name).To(Equal("ClusterState"))
+		clusterID, ok := payload["id"].(string)
 		Expect(ok).To(Equal(true))
 		Expect(clusterID).To(Equal(expectedClusterID))
 		return


### PR DESCRIPTION
Require to ease ccx migration that will push cluster events enriched with host events