### PR TITLE
MGMT-20229: make sure events are sent in order

### DIFF
--- a/internal/onprem/hydrate.go
+++ b/internal/onprem/hydrate.go
@@ -3,7 +3,6 @@ package onprem
 import (
 	"context"
 	"encoding/json"
-	"sync"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-assisted/assisted-events-streams/internal/types"
@@ -113,15 +112,9 @@ func (h *OnPremEventsHydrator) extractEvents(filename string, msg kafka.Message)
 		return
 	}
 
-	var wg sync.WaitGroup
 	for event := range eventChannel {
-		wg.Add(1)
-		go func(event types.EventEnvelope) {
-			h.notifyEvent(event)
-			wg.Done()
-		}(event)
+		h.notifyEvent(event)
 	}
-	wg.Wait()
 	h.ackChannel <- msg
 }
 


### PR DESCRIPTION
Many events arrive without metadata. This is probably the reason.

cc @pastequo 