### PR TITLE
MGMT-20928: Update golangci-lint version and config for Go 1.23 compatibility

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,33 +14,33 @@ run:
 
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
   # print lines of code with issue, default is true
   print-issued-lines: true
 
   # print linter name in the end of issue text, default is true
   print-linter-name: true
 
+issues:
   # make issues output unique by line, default is true
   uniq-by-line: true
 
 linters:
   enable:
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - govet
     - gocyclo
     - gofmt
     - unconvert
     - gci
     - goimports
-    - exportloopref
+    - copyloopvar
 
 linters-settings:
   govet:
-    check-shadowing: true
-
+    enable:
+      - shadow
     settings:
       printf:
         funcs:

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -19,4 +19,4 @@ RUN curl -sS -Lo ./kind https://kind.sigs.k8s.io/dl/v0.12.0/kind-linux-amd64 &&\
 
 ENV GOFLAGS=-mod=vendor
 COPY --from=quay.io/openshift/origin-cli:4.10 /usr/bin/oc /usr/bin/kubectl /usr/bin/
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.59.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.64.7


### PR DESCRIPTION
[MGMT-20928](https://issues.redhat.com//browse/MGMT-20928): Update golangci-lint version and config for Go 1.23 compatibility

- Bump golangci-lint version in Dockerfile.build to v1.64.7
- Modernize .golangci.yaml
- Ensure linter runs and passes with new config
- Ran all unit tests and validate, all passed

This is a sub-task of the larger task to bump Golang version to 1.23 across all repositories: https://issues.redhat.com/browse/MGMT-20675